### PR TITLE
Refactoring to support more constraint and control types

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,18 +81,18 @@ The solver supports the ability to terminate optimisation based on an arbitrary 
 
 The algorithm must be used with at least one stopping condition. By default this will be an iteration limit of 32.
 
-The built in stopping conditions are `IterationStop` and `TimeStop`. Each is instantiated with their limit (number of iterations and seconds respectively) and passed to `optimize!`.
+The built in stopping conditions are `IterationCondition` and `TimeCondition`. Each is instantiated with their limit (number of iterations and seconds respectively) and passed to `optimize!`.
 
 To use a single stopping condition:
 ```julia
-time_limit = TimeStop(30) #A 30 second time limit
+time_limit = TimeCondition(30) #A 30 second time limit
 optimize!(model, time_limit)
 ```
 
 Use multiple stopping conditions by passing them as a vector:
 ```julia
-time_limit = TimeStop(30) #A 30 second time limit
-iteration_limit = IterationStop(15) #Stop after 15 iterations
+time_limit = TimeCondition(30) #A 30 second time limit
+iteration_limit = IterationCondition(15) #Stop after 15 iterations
 optimize!(model, [time_limit, iteration_limit])
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The package contains a [JuMP](https://jump.dev/JuMP.jl/dev/) interface, but may 
 pkg> add https://github.com/ImperialCollegeLondon/RowActionMethods.jl
 ```
 
-## Usage 
+## Usage
 
 The following example solves a QP problem in 3 dimensions and can be formulated the same as any other JuMP problem. Note that the problem has the form `½(x'Ex)+F'x s.t. Mx≦γ`. Also note that RowActionMethods.jl defines `const RAM = RowActionMethods` as a shorthand.
 
@@ -66,9 +66,9 @@ for i=1:3
     AddConstraint(model, M[i,:], γ[i])
 end
 
-Optimize(model)
+optimize!(model)
 
-println(GetObjectiveValue(model))
+println(objective_value(model))
 println(GetVariables(model))
 ```
 
@@ -81,19 +81,19 @@ The solver supports the ability to terminate optimisation based on an arbitrary 
 
 The algorithm must be used with at least one stopping condition. By default this will be an iteration limit of 32.
 
-The built in stopping conditions are `IterationStop` and `TimeStop`. Each is instantiated with their limit (number of iterations and seconds respectively) and passed to `Optimize`.
+The built in stopping conditions are `IterationStop` and `TimeStop`. Each is instantiated with their limit (number of iterations and seconds respectively) and passed to `optimize!`.
 
 To use a single stopping condition:
 ```julia
 time_limit = TimeStop(30) #A 30 second time limit
-Optimize(model, time_limit)
+optimize!(model, time_limit)
 ```
 
 Use multiple stopping conditions by passing them as a vector:
 ```julia
 time_limit = TimeStop(30) #A 30 second time limit
 iteration_limit = IterationStop(15) #Stop after 15 iterations
-Optimize(model, [time_limit, iteration_limit])
+optimize!(model, [time_limit, iteration_limit])
 ```
 
 The ordering of the vector does not impact the solver. Custom stopping conditions can be defined easily. See the documentation for a guide on implementing these.

--- a/docs/src/ref/public.md
+++ b/docs/src/ref/public.md
@@ -1,6 +1,6 @@
 ```@docs
 GetModel(method::String)
-Optimize(model::RAM.RAMProblem)
-Optimize(model::RAM.RAMProblem, s::RAM.StoppingCondition)
-Optimize(model::RAM.RAMProblem{T,F}, conditions::Vector{S}) where {T,F,S<:RAM.StoppingCondition}
+optimize!(model::RAM.RAMProblem)
+optimize!(model::RAM.RAMProblem, s::RAM.StoppingCondition)
+optimize!(model::RAM.RAMProblem{T,F}, conditions::Vector{S}) where {T,F,S<:RAM.StoppingCondition}
 ```

--- a/src/Constraints.jl
+++ b/src/Constraints.jl
@@ -46,7 +46,7 @@ function is_model_empty(model::RAMProblem)
            model.variable_count == 0 &&
            model.constraints.max_constraint_index == 0 &&
            model.constraints.constraint_count == 0 &&
-           model.status == OPTIMIZE_NOT_CALLED() &&
+           model.status == OPTIMIZE_NOT_CALLED &&
            model.iterations == 0
 end
 

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -128,10 +128,17 @@ function _init_run(model::RAMProblem)
     model.statistics.BuildTime = time() - t1
 end
 
-optimize!(model::RAMProblem, ::Nothing) = optimize!(model)
 
 """
-    optimize!(model::RAMProblem)
+    optimize!(model::RAMProblem, s::StoppingCondition)
+
+As [`optimize!`](@ref optimize!(model::RAMProblem{T,F}, conditions::Vector{S} = [IterationStop(32)])) but takes
+a single stopping condition to end on rather than a vector of stopping conditons.
+"""
+optimize!(model::RAMProblem, s::StoppingCondition) = optimize!(model, [s])
+
+"""
+    optimize!(model::RAMProblem{T,F}, conditions::Vector{S} = [IterationStop(32)]) where {T,F,S<:StoppingCondition}
 
 Iterate `model.method` algorithm until a stopping condition has been met, then
 set the termination status and calculate the primal solution.
@@ -143,24 +150,10 @@ If configured as multi threaded then `IterateRow` is called for each index in th
 variable returned by `GetTempVar`. Calls to `IterateRow` are distributed amongst all
 available threads.
 
-Configures the algorithm to terminate after 32 iterations.
+By default, `conditions` contains only an iteration termination criteria to terminate the algorithm
+after 32 iterations.
 """
-optimize!(model::RAMProblem) = optimize!(model, [IterationStop(32)])
-
-"""
-    optimize!(model::RAMProblem, s::StoppingCondition)
-
-As [`optimize!`](@ref optimize!(::RAM.RAMProblem)) but takes a single stopping condition to end on rather than
-the default.
-"""
-optimize!(model::RAMProblem, s::StoppingCondition) = optimize!(model, [s])
-
-"""
-    optimize!(model::RAMProblem{T,F}, conditions::Vector{S}) where {T,F,S<:StoppingCondition}
-
-As [`optimize!`](@ref optimize!(::RAM.RAMProblem)) but takes a vector of single stopping conditions to end on.
-"""
-function optimize!(model::RAMProblem{T,F}, conditions::Vector{S}) where {T,F,S<:StoppingCondition}
+function optimize!(model::RAMProblem{T,F}, conditions::Vector{S} = [IterationStop(32)]) where {T,F,S<:StoppingCondition}
 
     _init_run(model)
 

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -1,4 +1,4 @@
-export GetModel, Optimize, SetThreads, GetVariables, GetObjectiveValue
+export GetModel, optimize!, SetThreads, GetVariables, objective_value
 
 """
     GetModel(model::String; kwargs...)::RAMProblem
@@ -88,20 +88,20 @@ GetTempVar(m::RAMProblem) = GetTempVar(m.method)
 VarUpdate(m::RAMProblem{T}, var::Vector{T}) where T = VarUpdate(m.method, var)
 
 """
-    GetObjectiveValue(model::RAMProblem{T,F})::T
+    objective_value(model::RAMProblem{T,F})::T
 
 Return the evaluated objective for the current solution.
 """
-(GetObjectiveValue(model::RAMProblem{T,F})::T) where {T,F}=
-    GetObjectiveValue(model, ObjectiveType(model.method))
+(objective_value(model::RAMProblem{T,F})::T) where {T,F}=
+    objective_value(model, ObjectiveType(model.method))
 
 
 """
-    GetObjectiveValue(model::RAMProblem, ::Quadratic)
+    objective_value(model::RAMProblem, ::Quadratic)
 
 Evaluate the cost of the objective function for a quadratic objective.
 """
-function GetObjectiveValue(model::RAMProblem, ::Quadratic)
+function objective_value(model::RAMProblem, ::Quadratic)
     B, d = GetObjective(model)
     x = GetVariables(model)
 
@@ -128,10 +128,10 @@ function RunBuild(model::RAMProblem)
     model.statistics.BuildTime = time() - t1
 end
 
-Optimize(model::RAMProblem, ::Nothing) = Optimize(model)
+optimize!(model::RAMProblem, ::Nothing) = optimize!(model)
 
 """
-    Optimize(model::RAMProblem)
+    optimize!(model::RAMProblem)
 
 Iterate `model.method` algorithm until a stopping condition has been met, then
 set the termination status and calculate the primal solution.
@@ -145,22 +145,22 @@ available threads.
 
 Configures the algorithm to terminate after 32 iterations.
 """
-Optimize(model::RAMProblem) = Optimize(model, [IterationStop(32)])
+optimize!(model::RAMProblem) = optimize!(model, [IterationStop(32)])
 
 """
-    Optimize(model::RAMProblem, s::StoppingCondition)
+    optimize!(model::RAMProblem, s::StoppingCondition)
 
-As [`Optimize`](@ref Optimize(::RAM.RAMProblem)) but takes a single stopping condition to end on rather than
+As [`optimize!`](@ref optimize!(::RAM.RAMProblem)) but takes a single stopping condition to end on rather than
 the default.
 """
-Optimize(model::RAMProblem, s::StoppingCondition) = Optimize(model, [s])
+optimize!(model::RAMProblem, s::StoppingCondition) = optimize!(model, [s])
 
 """
-    Optimize(model::RAMProblem{T,F}, conditions::Vector{S}) where {T,F,S<:StoppingCondition}
+    optimize!(model::RAMProblem{T,F}, conditions::Vector{S}) where {T,F,S<:StoppingCondition}
 
-As [`Optimize`](@ref Optimize(::RAM.RAMProblem)) but takes a vector of single stopping conditions to end on.
+As [`optimize!`](@ref optimize!(::RAM.RAMProblem)) but takes a vector of single stopping conditions to end on.
 """
-function Optimize(model::RAMProblem{T,F}, conditions::Vector{S}) where {T,F,S<:StoppingCondition}
+function optimize!(model::RAMProblem{T,F}, conditions::Vector{S}) where {T,F,S<:StoppingCondition}
 
     RunBuild(model)
 

--- a/src/Hildreth.jl
+++ b/src/Hildreth.jl
@@ -35,7 +35,7 @@ mutable struct Hildreth{T} <: ModelFormulation
     end
 end
 
-ObjectiveType(::Hildreth) = Quadratic()
+_objective_type(::Hildreth) = Quadratic()
 SupportsVariableDeletion(::Hildreth) = true
 
 function DeleteVariable(method::Hildreth, index)

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -233,11 +233,11 @@ end
 
 #Maps internal RAM termination conditions to MOI equivalents
 RAM_MOI_Termination_Map = Dict(
-                               RAM.OPTIMIZE_NOT_CALLED() => MOI.OPTIMIZE_NOT_CALLED,
-                               RAM.OPTIMAL()             => MOI.OPTIMAL,
-                               RAM.INFEASIBLE()          => MOI.INFEASIBLE,
-                               RAM.ITERATION_LIMIT()     => MOI.ITERATION_LIMIT,
-                               RAM.TIME_LIMIT()          => MOI.TIME_LIMIT
+                               RAM.OPTIMIZE_NOT_CALLED      => MOI.OPTIMIZE_NOT_CALLED,
+                               RAM.OPTIMAL                  => MOI.OPTIMAL,
+                               RAM.INFEASIBLE               => MOI.INFEASIBLE,
+                               RAM.ITERATION_LIMIT_REACHED  => MOI.ITERATION_LIMIT,
+                               RAM.TIME_LIMIT_REACHED       => MOI.TIME_LIMIT
                               )
 
 function MOI.get(model::Optimizer, ::MOI.TerminationStatus)

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -47,7 +47,7 @@ end
 #= Model Actions =#
 function MOI.optimize!(model::Optimizer)
     RAM.SetThreads(model.inner_model; threads = model.threads)
-    RAM.Optimize(model.inner_model, model.stopping_conditions)
+    RAM.optimize!(model.inner_model, model.stopping_conditions)
 end
 
 #= Custom Options =#
@@ -246,7 +246,7 @@ end
 
 function MOI.get(model::Optimizer, ::MOI.ObjectiveValue)
     sense = model.sense == MOI.MAX_SENSE ? -1 : 1
-    return sense * RAM.GetObjectiveValue(model.inner_model)
+    return sense * RAM.objective_value(model.inner_model)
 end
 
 function MOI.get(model::Optimizer, ::MOI.VariablePrimal, vi::MOI.VariableIndex)

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -67,12 +67,12 @@ end
 #= Model Status =#
 function MOI.supports(model::Optimizer,
                       ::MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}})
-    return RAM.ObjectiveType(model.inner_model) == RAM.Quadratic()
+    return RAM._objective_type(model.inner_model) == RAM.Quadratic()
 end
 
 function MOI.supports(model::Optimizer,
                       ::MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}})
-    return RAM.ObjectiveType(model.inner_model) == RAM.Linear()
+    return RAM._objective_type(model.inner_model) == RAM.Linear()
 end
 
 MOI.supports(::Optimizer, ::MOI.ObjectiveSense) = true

--- a/src/StopConditions.jl
+++ b/src/StopConditions.jl
@@ -17,7 +17,7 @@ function SetTerminationStatus(model::RAMProblem, conditions::Vector{S}) where {S
 end
 
 """
-    check_stopcondition!(model::ModelFormulation, conditions::StoppingCondition)::Bool
+    _check_stopconditions!(model::ModelFormulation, conditions::StoppingCondition)::Bool
 
 Returns true if a condition for stopping has been met. Also updates model's termination
 status variable with the value returned by the activated stopping condition.
@@ -26,7 +26,7 @@ Note that the termination variables should be mapped to the MathOptInterface ter
 status codes in MOI_wrapper.jl. If your stopping condition fits an MOI condition that has
 not been implemented, then please update the wrapper accordingly.
 """
-function check_stopcondition(model::RAMProblem, conditions::Vector{S}
+function _check_stopconditions(model::RAMProblem, conditions::Vector{S}
                             )::Bool where {S<:StoppingCondition}
 
     for c in conditions

--- a/src/StopConditions.jl
+++ b/src/StopConditions.jl
@@ -1,4 +1,4 @@
-export IterationStop, TimeStop
+export IterationCondition, TimeCondition
 
 """
 All stopping conditions take a condition that extends the StoppingCondition
@@ -6,18 +6,14 @@ abstract type.
 """
 abstract type StoppingCondition end
 
-SetTerminationStatus(m::RAMProblem, c::StoppingCondition) = SetTerminationCondition(m, [c])
+status_code(::StoppingCondition) = OTHER_TERMINATION_CONDITION
+status_string(::StoppingCondition) = "Unknown termination criteria reached"
+init_stopcondition(::RAMProblem, ::StoppingCondition) = Nothing
+test_stopcondition(::RAMProblem, ::StoppingCondition) = error("No stopping condition test function defined")
 
-function SetTerminationStatus(model::RAMProblem, conditions::Vector{S}) where {S<:StoppingCondition}
-    for c in conditions
-        !stopcondition(model, c) && continue
-        model.status = StopConditionStatus(c)
-        break
-    end
-end
 
 """
-    _check_stopconditions!(model::ModelFormulation, conditions::StoppingCondition)::Bool
+    _check_stopconditions(model::ModelFormulation, conditions::StoppingCondition)::Bool
 
 Returns true if a condition for stopping has been met. Also updates model's termination
 status variable with the value returned by the activated stopping condition.
@@ -27,58 +23,79 @@ status codes in MOI_wrapper.jl. If your stopping condition fits an MOI condition
 not been implemented, then please update the wrapper accordingly.
 """
 function _check_stopconditions(model::RAMProblem, conditions::Vector{S}
-                            )::Bool where {S<:StoppingCondition}
+                               )::Bool where {S<:StoppingCondition}
 
     for c in conditions
-        stopcondition(model, c) && return true
+        if test_stopcondition(model, c)
+            model.status = status_code(c)
+            model.status_string = status_string(c)
+            return false
+        end
     end
-    return false
+
+    return true
 end
 
-"""
-    IterationStop(num)
 
-A stop condition that halts after 'num' iterations.
+function _init_stopconditions(model::RAMProblem, conditions::Vector{StoppingCondition})
+    for c in conditions
+        init_stopcondition(model, c)
+    end
+end
+
+
 """
-struct IterationStop <: StoppingCondition
+    IterationCondition(num)
+
+Stop the execution after ``num`` iterations.
+"""
+struct IterationCondition <: StoppingCondition
     value::Int64
+
+    function IterationCondition(num::Int64)
+        if num < 1
+            throw( DomainError(num, "Must specify more than one iteration") )
+        end
+
+        return new(num)
+    end
 end
 
-StopConditionStatus(::IterationStop) = ITERATION_LIMIT()
+status_code(::IterationCondition) = ITERATION_LIMIT_REACHED
+status_string(sc::IterationCondition) = "Reached iteration limit of $(sc.value) iterations"
 
 
-
-"""
-    stopcondition(v::WorkingVars, iterations_limit::IterationStop)
-
-Checks if the number of iterations has exceeded a maximum.
-"""
-function stopcondition(model::RAMProblem, iterations_limit::IterationStop)::Bool
+function test_stopcondition(model::RAMProblem, iterations_limit::IterationCondition)::Bool
     return model.iterations >= iterations_limit.value
 end
 
-mutable struct TimeStop <: StoppingCondition
-    running::Bool
-    start::Int64
-    limit::Int64
-    function TimeStop(limit::Int64)
-        t = new()
-        t.running = false
-        t.limit = limit
-        return t
+
+"""
+    TimeCondition(limit::Float64)
+
+Stop the execution of the algorithm after `limit` seconds has elapsed.
+"""
+mutable struct TimeCondition <: StoppingCondition
+    start::Float64
+    limit::Float64
+
+    function TimeCondition(limit::Float64)
+        if limit <= 0.0
+            throw( DomainError(limit, "Time must be postive") )
+        end
+
+        return new(0.0, limit)
     end
 end
 
-function stopcondition(model::RAMProblem, time_limit::TimeStop)
-    #Start condition if first time
-    if time_limit.running == false
-        time_limit.running = true
-        time_limit.start = floor(time())
-        return false
-    end
 
-    #Otherwise check if elapsed time is greater than limit
-    return floor(time()) - time_limit.start > time_limit.limit
+function test_stopcondition(::RAMProblem, time_limit::TimeCondition)
+    return ( time() - time_limit.start ) > time_limit.limit
 end
 
-StopConditionStatus(::TimeStop) = TIME_LIMIT()
+function init_stopcondition(::RAMProblem, tc::TimeCondition)
+    tc.start = time()
+end
+
+status_code(::TimeCondition) = TIME_LIMIT_REACHED
+status_string(sc::TimeCondition) = "Reached time limit of $(sc.limit) seconds"

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -81,14 +81,14 @@ mutable struct Constraints{T,F}
     end
 end
 
-abstract type AbstractStatus end
-
-struct OPTIMIZE_NOT_CALLED              <: AbstractStatus end
-struct OPTIMAL                          <: AbstractStatus end
-struct INFEASIBLE                       <: AbstractStatus end
-struct ITERATION_LIMIT                  <: AbstractStatus end
-struct TIME_LIMIT                       <: AbstractStatus end
-struct UNKNOWN_TERMINATION_CONDITION    <: AbstractStatus end
+@enum OptimizationStatus begin
+    OPTIMIZE_NOT_CALLED
+    OPTIMAL
+    INFEASIBLE
+    ITERATION_LIMIT_REACHED
+    TIME_LIMIT_REACHED
+    OTHER_TERMINATION_CONDITION
+end
 
 mutable struct RAMProblem{T,F}
     #== Variables ==#
@@ -102,7 +102,8 @@ mutable struct RAMProblem{T,F}
     result::Union{SparseVector{T},Nothing}
 
     #== General ==#
-    status::AbstractStatus
+    status::OptimizationStatus
+    status_string::String
     iterations::F
     method::ModelFormulation
 
@@ -119,7 +120,7 @@ mutable struct RAMProblem{T,F}
         p.constraints = Constraints{T,F}()
 
         p.variable_count = 0
-        p.status = OPTIMIZE_NOT_CALLED()
+        p.status = OPTIMIZE_NOT_CALLED
         p.iterations = 0
         p.result = nothing
         p.threads = false

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -18,7 +18,7 @@ abstract type ModelFormulation end
 abstract type AbstractObjectiveType end
 struct Quadratic <: AbstractObjectiveType end
 struct Linear <: AbstractObjectiveType end
-ObjectiveType(m::ModelFormulation) = error("$(typeof(m)) should define an objective function type")
+_objective_type(m::ModelFormulation) = error("$(typeof(m)) should define an objective function type")
 
 abstract type AbstractObjective end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -39,10 +39,10 @@ struct SparseQuadraticObjective{T} <: AbstractObjective
     end
 end
 
-mutable struct Statistics{T}
-    BuildTime::T
-    OptimizeTime::T
-    Statistics{T}() where T = new(0.0, 0.0)
+mutable struct Statistics
+    BuildTime::Float64
+    OptimizeTime::Float64
+    Statistics()= new(0.0, 0.0)
 end
 
 
@@ -110,7 +110,7 @@ mutable struct RAMProblem{T,F}
     #== Threading ==#
     threads::Bool
 
-    statistics::Statistics{T}
+    statistics::Statistics
 
     RAMProblem(model::String; kwargs...) = RAMProblem{Float64, Int64}(model; kwargs...)
     function RAMProblem{T,F}(model::String; kwargs...) where {T,F}
@@ -125,7 +125,7 @@ mutable struct RAMProblem{T,F}
         p.result = nothing
         p.threads = false
 
-        p.statistics = Statistics{T}()
+        p.statistics = Statistics()
 
         p.method = method_mapping[model]{T}(;kwargs...)
         return p

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using RowActionMethods
 using LinearAlgebra
 using Test
 
-include("test_Core.jl")
-
+include( "test_Core.jl" )
+include( "test_StopConditions.jl" )
 
 

--- a/test/test_Core.jl
+++ b/test/test_Core.jl
@@ -15,9 +15,9 @@
         @test typeof(problem.method) == RAM.Hildreth{Float64}
     end
 
-    @testset "ObjectiveType" begin
+    @testset "_objective_type" begin
         problem = RAM.GetModel("Hildreth")
-        @test RAM.ObjectiveType(problem) == RAM.ObjectiveType(problem.method) == RAM.Quadratic()
+        @test RAM._objective_type(problem) == RAM._objective_type(problem.method) == RAM.Quadratic()
     end
 
     @testset "SetThreads" begin
@@ -54,7 +54,7 @@
     @testset "objective_value" begin end
 
     @testset "Setup" begin end
-    @testset "RunBuild" begin end
+    @testset "_init_run" begin end
     @testset "optimize!" begin end
 
 

--- a/test/test_Core.jl
+++ b/test/test_Core.jl
@@ -46,16 +46,16 @@
     @testset "GetVariables" begin end
     @testset "is_empty" begin end
     @testset "get_model_status" begin end
-    @testset "GetObjectiveValue" begin end
+    @testset "objective_value" begin end
     @testset "SupportsDeleteConstraint" begin end
     @testset "IterateRow" begin end
     @testset "GetTempVar" begin end
     @testset "VarUpdate" begin end
-    @testset "GetObjectiveValue" begin end
+    @testset "objective_value" begin end
 
     @testset "Setup" begin end
     @testset "RunBuild" begin end
-    @testset "Optimize" begin end
+    @testset "optimize!" begin end
 
 
 end

--- a/test/test_StopConditions.jl
+++ b/test/test_StopConditions.jl
@@ -1,0 +1,87 @@
+@testset "Stop Conditions" begin
+
+    @testset "Iteration Limit" begin
+        @test_throws DomainError IterationCondition(0)
+        @test_throws DomainError IterationCondition(-1)
+
+        ic    = IterationCondition(3)
+        model = RAM.RAMProblem{Float64, Int64}("Hildreth")
+        model.iterations = 0
+
+        # Verify the condition works
+        @test !RAM.test_stopcondition(model, ic)
+
+        model.iterations = 1
+        @test !RAM.test_stopcondition(model, ic)
+
+        model.iterations = 2
+        @test !RAM.test_stopcondition(model, ic)
+
+        model.iterations = 3
+        @test RAM.test_stopcondition(model, ic)
+
+        # Verify it has the right status code
+        @test RAM.status_code(ic) == RAM.ITERATION_LIMIT_REACHED
+    end
+
+    @testset "Time Limit" begin
+        @test_throws DomainError TimeCondition(0.0)
+        @test_throws DomainError TimeCondition(-1.0)
+
+        tc    = TimeCondition(5.0)
+        model = RAM.RAMProblem{Float64, Int64}("Hildreth")
+
+        # Verify it initialized properly
+        @test tc.start ≈ 0.0
+        RAM.init_stopcondition(model, tc)
+        @test tc.start > 0.0
+
+        # Verify the condition works
+        @test !RAM.test_stopcondition(model, tc)
+
+        sleep(2.0)
+        @test !RAM.test_stopcondition(model, tc)
+
+        sleep(4.0)
+        @test RAM.test_stopcondition(model, tc)
+
+        # Verify it has the right status code
+        @test RAM.status_code(tc) == RAM.TIME_LIMIT_REACHED
+    end
+
+    @testset "Multiple conditions" begin
+        let model = RAM.RAMProblem{Float64, Int64}("Hildreth"),
+            stopVec = [ IterationCondition(3);
+                        TimeCondition(5.0) ]
+
+            # Ensure the TimeCondition started properly
+            RAM._init_stopconditions(model, stopVec)
+            @test stopVec[2].start > 0
+
+            # Test that the first stop condition fires when it is supposed to
+            model.iterations = 0
+            @test RAM._check_stopconditions(model, stopVec)
+            sleep(6.0)
+            @test !RAM._check_stopconditions(model, stopVec)
+
+            @test model.status == RAM.TIME_LIMIT_REACHED
+        end
+
+        # Rebuild the parts to try the other condition this time
+        let model = RAM.RAMProblem{Float64, Int64}("Hildreth"),
+            stopVec = [ IterationCondition(3);
+                        TimeCondition(500.0) ]
+
+            RAM._init_stopconditions(model, stopVec)
+
+            model.iterations = 0
+            @test RAM._check_stopconditions(model, stopVec)
+            model.iterations = 1
+            @test RAM._check_stopconditions(model, stopVec)
+            model.iterations = 3
+            @test !RAM._check_stopconditions(model, stopVec)
+            @test model.status == RAM.ITERATION_LIMIT_REACHED
+        end
+    end
+
+end


### PR DESCRIPTION
This is a somewhat large refactor to support more constraint types and also introduce the idea of the control to the selection of the constraints being projected each iteration.

Currently this is just some cleanup of the current types and stopping conditions, and the introduction of some more unit tests. These changes bring the code more in line with the JuMP coding style and interface, which we should be trying to follow in our native API if possible (it makes it easier to switch between the MOI and native API if needed).